### PR TITLE
Add ability to validate .traker.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Schema breakdown:
 * `environments.<key>.name` - the name of the rake task in namespace:name format
 * `environments.<key>.notes` - some information that might be important when the task is run (should be different from rake task's description)
 
+### Testing
+
+Traker allows to keep your `.traker.yml` configuration file consistent and valid. Run a generator to install rspec related files:
+
+``` ruby
+rails g traker:rspec test
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/generators/traker/rspec_generator.rb
+++ b/lib/generators/traker/rspec_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails/generators/active_record'
+
+module Traker
+  module Generators
+    # A rails generator that generates rspec-related files in the host
+    # Ruby On Rails project
+    class RspecGenerator < ActiveRecord::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
+      def generate_spec
+        template 'spec/lib/traker_spec.rb', 'spec/lib/traker_spec.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/traker/templates/spec/lib/traker_spec.rb
+++ b/lib/generators/traker/templates/spec/lib/traker_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'traker'
+
+describe '.traker.yml' do
+  it 'is valid' do
+    Rails.application.load_tasks
+    expect { Traker::Config.load.validate!(Rake::Task.tasks) }.not_to raise_error
+  end
+end

--- a/lib/traker.rb
+++ b/lib/traker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'traker/version'
+require 'traker/config'
 require 'traker/instrumenter'
 require 'traker/task'
 

--- a/lib/traker/config.rb
+++ b/lib/traker/config.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Traker
+  # Represents Traker configuration.
+  class Config
+    PATH = '.traker.yml'
+
+    class InvalidTasks < StandardError
+    end
+
+    def self.load
+      Config.new(File.join(Rails.root, PATH))
+    end
+
+    def initialize(file)
+      yml = YAML.safe_load(File.read(file))
+      @environments = yml['environments']
+    end
+
+    def env
+      @env ||= ENV.fetch('TRAKER_ENV', 'default')
+    end
+
+    def tasks_to_be_run
+      @environments[env] || []
+    end
+
+    def validate!(available_tasks)
+      available_task_names = available_tasks.map(&:name)
+
+      @environments.each do |_, tasks|
+        task_names = tasks.map { |t| t['name'] }
+        invalid_tasks = task_names - available_task_names
+
+        if invalid_tasks.any?
+          raise InvalidTasks, "#{PATH} contains invalid tasks: #{invalid_tasks.join(',')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/traker/instrumenter.rb
+++ b/lib/traker/instrumenter.rb
@@ -1,25 +1,24 @@
 # frozen_string_literal: true
 
-require 'yaml'
-
 module Traker
   # Wraps array of rake tasks, and auguments each one of them
   # with Traker features
   class Instrumenter
-    attr_accessor :tasks
+    attr_accessor :tasks, :config
 
     def initialize(tasks)
       @tasks = tasks
+      @config = Traker::Config.load
     end
 
     def instrument
       tasks.each do |t|
         task_name = t.name
 
-        next unless tasks_to_be_run.map { |task| task['name'] }.include?(task_name)
+        next unless config.tasks_to_be_run.map { |task| task['name'] }.include?(task_name)
 
         handler = proc do |&block|
-          record = Traker::Task.find_or_initialize_by(name: task_name, environment: env)
+          record = Traker::Task.find_or_initialize_by(name: task_name, environment: config.env)
 
           record.started_at = DateTime.now
           record.is_success = true
@@ -39,20 +38,6 @@ module Traker
 
         yield task_name, handler
       end
-    end
-
-    private
-
-    def config
-      @config ||= YAML.safe_load(File.read(File.join(Rails.root, '.traker.yml')))
-    end
-
-    def env
-      @env ||= ENV.fetch('TRAKER_ENV', 'default')
-    end
-
-    def tasks_to_be_run
-      config['environments'][env] || []
     end
   end
 end

--- a/lib/traker/override.rake
+++ b/lib/traker/override.rake
@@ -2,8 +2,6 @@
 
 require_relative '../traker'
 
-Traker::Instrumenter.new(Rake::Task.tasks)
-
 Traker::Instrumenter.new(Rake::Task.tasks).instrument do |task_name, handle_task|
   original_task = Rake.application.instance_variable_get('@tasks').delete(task_name)
   task_prerequisites = original_task.prerequisites | ['environment']

--- a/spec/traker/config_spec.rb
+++ b/spec/traker/config_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe Traker::Config do
+  subject { Traker::Config.load }
+
+  describe '.load' do
+    it { is_expected.not_to be_blank }
+  end
+
+  describe '#env' do
+    it 'returns default env' do
+      expect(subject.env).to eq 'default'
+    end
+
+    it 'returns the modified env' do
+      with_modified_env TRAKER_ENV: 'dev' do
+        expect(subject.env).to eq 'dev'
+      end
+    end
+  end
+
+  describe '#tasks_to_be_run' do
+    it 'returns default tasks to be run' do
+      with_modified_env TRAKER_ENV: 'dev' do
+        expect(subject.tasks_to_be_run)
+          .to eq [{ 'name' => 'traker:rake_success' }, { 'name' => 'traker:rake_failure' }]
+      end
+    end
+  end
+
+  describe '#validate!' do
+    let(:available_tasks) do
+    end
+
+    it 'raises if there is a task mismatch' do
+      available_tasks = [
+        OpenStruct.new(name: 'task1'),
+        OpenStruct.new(name: 'task2')
+      ]
+      expect { subject.validate!(available_tasks) }
+        .to raise_error Traker::Config::InvalidTasks, '.traker.yml contains invalid tasks: traker:rake_success,traker:rake_failure'
+    end
+
+    it 'validates if tasks match' do
+      available_tasks = [
+        OpenStruct.new(name: 'traker:rake_success'),
+        OpenStruct.new(name: 'traker:rake_failure')
+      ]
+      expect { subject.validate!(available_tasks) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a possibility to maintain/validate `.traker.yml` by the end app using specs.

- [x] created `Config` entity which represents the config itself and implements the `#validate!` method.
- [x] added a spec generator, which creates an rspec file to validate the `.traker.yml`
- [x] added specs and docs