### PR TITLE
Do not break the rake task when traker config is invalid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    traker (0.0.1)
+    traker (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -69,7 +69,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)

--- a/lib/traker/config.rb
+++ b/lib/traker/config.rb
@@ -18,6 +18,9 @@ module Traker
     def initialize(file)
       yml = YAML.safe_load(File.read(file))
       @environments = yml['environments']
+    rescue Psych::SyntaxError => e
+      puts "[TRAKER] unable to load config file: #{e}"
+      @environments = {}
     end
 
     def env

--- a/spec/support/.invalid_traker.yml
+++ b/spec/support/.invalid_traker.yml
@@ -1,0 +1,3 @@
+bad yml
+
+name:

--- a/spec/traker/config_spec.rb
+++ b/spec/traker/config_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Traker::Config do
 
   describe '#initialize' do
     it 'does not fail if config has incorrect syntax' do
-      expect { Traker::Config.new("./spec/support/.invalid_traker.yml") }
+      expect { Traker::Config.new('./spec/support/.invalid_traker.yml') }
         .not_to raise_error
     end
   end

--- a/spec/traker/config_spec.rb
+++ b/spec/traker/config_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Traker::Config do
     it { is_expected.not_to be_blank }
   end
 
+  describe '#initialize' do
+    it 'does not fail if config has incorrect syntax' do
+      expect { Traker::Config.new("./spec/support/.invalid_traker.yml") }
+        .not_to raise_error
+    end
+  end
+
   describe '#env' do
     it 'returns default env' do
       expect(subject.env).to eq 'default'


### PR DESCRIPTION
When the config is invalid, traker doesn't allow to run any rake task. 

In this PR we just rescue the YML parsing error, print the error message, and do not prevent the rake task from running. 

Also, i had to update the mimemagic, since they [yanked all the stale versions](https://github.com/mimemagicrb/mimemagic/issues/148) because of the licensing issue.