### PR TITLE
Allow tasks with parameters

### DIFF
--- a/lib/traker/config.rb
+++ b/lib/traker/config.rb
@@ -32,15 +32,27 @@ module Traker
     end
 
     def validate!(available_tasks)
-      available_task_names = available_tasks.map(&:name)
+      available_task_names = available_tasks.map { |t| extract_task_name(t[:name]) }
 
       @environments.each do |_, tasks|
-        task_names = (tasks || []).map { |t| t['name'] }
+        task_names = (tasks || []).map { |t| extract_task_name(t['name']) }
         invalid_tasks = task_names - available_task_names
 
         if invalid_tasks.any?
           raise InvalidTasks, "#{PATH} contains invalid tasks: #{invalid_tasks.join(',')}"
         end
+      end
+    end
+
+    private
+
+    # Extracts task name without arguments
+    def extract_task_name(str)
+      matches = str.match(/^(?<name>[^\[\]]*)(?:(\[.*\])?)$/) # Task name with optional parameters
+      if matches.try(:names).blank?
+        raise InvalidTasks, "#{PATH} contains a bad formatted task: #{str}"
+      else
+        matches[:name]
       end
     end
   end

--- a/spec/traker/config_spec.rb
+++ b/spec/traker/config_spec.rb
@@ -56,5 +56,24 @@ RSpec.describe Traker::Config do
       ]
       expect { subject.validate!(available_tasks) }.not_to raise_error
     end
+
+    it 'validates if tasks with parameters match' do
+      available_tasks = [
+        OpenStruct.new(name: 'traker:rake_success1[foo]'),
+        OpenStruct.new(name: 'traker:rake_success'),
+        OpenStruct.new(name: 'traker:rake_fail[foo,bar]')
+      ]
+      expect { subject.validate!(available_tasks) }.not_to raise_error
+    end
+
+    it 'raises if there is a task with bad formatted parameters' do
+      available_tasks = [
+        OpenStruct.new(name: 'traker:rake_success1[foo'),
+        OpenStruct.new(name: 'traker:rake_success'),
+        OpenStruct.new(name: 'traker:rake_fail[]')
+      ]
+      expect { subject.validate!(available_tasks) }
+        .to raise_error Traker::Config::InvalidTasks, '.traker.yml contains a bad formatted task: traker:rake_success1[foo'
+    end
   end
 end


### PR DESCRIPTION
### Description
Traker doesn't allow tasks with parameters. In order to allow this, it compares rake task names without the parameters. It also validates if the task name has the proper format

### Related issue
* https://github.com/pavloo/traker/issues/13